### PR TITLE
Allow GitHub to detect our license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -169,26 +169,3 @@ accepting any such warranty or additional liability.
 
 _END OF TERMS AND CONDITIONS_
 
-### APPENDIX: How to apply the Apache License to your work
-
-To apply the Apache License to your work, attach the following boilerplate
-notice, with the fields enclosed by brackets `[]` replaced with your own
-identifying information. (Don't include the brackets!) The text should be
-enclosed in the appropriate comment syntax for the file format. We also
-recommend that a file or class name and description of purpose be included on
-the same “printed page” as the copyright notice for easier identification within
-third-party archives.
-
-    Copyright [yyyy] [name of copyright owner]
-    
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    
-      http://www.apache.org/licenses/LICENSE-2.0
-    
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.


### PR DESCRIPTION
Removing the appendix allows GH to detect the LICENSE. Since that's _after_ the "_END OF TERMS AND CONDITIONS_" marker that should not affect the license. Thoughts?