### PR TITLE
Fix travis building twice on PRs from our repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: generic
 
+# Build only commits on master and release tags for the "Build pushed branches" feature.
+# This prevents building twice on PRs originating from our repo ("Build pushed pull requests)".
+# See:
+#   - https://github.com/travis-ci/travis-ci/issues/1147
+#   - https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests
+branches:
+  only:
+    - master
+    - /v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$/
+
 jdk:
   - openjdk8
 


### PR DESCRIPTION
Build only commits on master and release tags for the "Build pushed branches" feature.
This prevents building twice on PRs originating from our repo ("Build pushed pull requests)".
See: 
  - https://github.com/travis-ci/travis-ci/issues/1147
  - https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests

TODO: 
- [x] reset author