### PR TITLE
Validate PSU with requested account for SCA

### DIFF
--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/AuthorisationService.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/AuthorisationService.java
@@ -15,6 +15,7 @@ import de.adorsys.psd2.xs2a.spi.domain.response.SpiResponse;
 import de.adorsys.psd2.xs2a.spi.domain.response.SpiResponseStatus;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,14 +38,16 @@ public class AuthorisationService {
    * @param aspspConsentData aspspConsentData
    */
   public SpiResponse<SpiAuthorisationStatus> authorisePsu(
-      SpiPsuData spiPsuData, String password, AspspConsentData aspspConsentData) {
+      SpiPsuData spiPsuData, String password, String iban, AspspConsentData aspspConsentData) {
 
-    Optional<PsuData> psu = testDataService.getPsu(spiPsuData.getPsuId());
+    Optional<PsuData> inquiringPsu = testDataService.getPsu(spiPsuData.getPsuId());
+    Optional<String> accountOwner = testDataService.getPsuByIban(iban);
 
-    if (!psu.isPresent() || !password.equals(psu.get().getPassword())) {
+    if (!inquiringPsu.isPresent() || !password.equals(inquiringPsu.get().getPassword())
+        || !accountOwner.isPresent() || !inquiringPsu.get().getPsuId().equals(accountOwner.get())) {
       return SpiResponse.<SpiAuthorisationStatus>builder()
           .aspspConsentData(aspspConsentData)
-          .payload(FAILURE)
+          .message(Collections.singletonList("Authorization failed"))
           .fail(SpiResponseStatus.UNAUTHORIZED_FAILURE);
     }
 

--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/ais/AisConsentSpiImpl.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/ais/AisConsentSpiImpl.java
@@ -56,7 +56,9 @@ public class AisConsentSpiImpl implements AisConsentSpi {
       SpiAccountConsent spiAccountConsent,
       AspspConsentData aspspConsentData) {
 
-    return authorisationService.authorisePsu(spiPsuData, password, aspspConsentData);
+    String iban = spiAccountConsent.getAccess().getAccounts().get(0).getIban();
+
+    return authorisationService.authorisePsu(spiPsuData, password, iban, aspspConsentData);
   }
 
   @Override

--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/pis/PaymentAuthorisationSpiImpl.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/pis/PaymentAuthorisationSpiImpl.java
@@ -5,6 +5,8 @@ import de.adorsys.psd2.xs2a.core.consent.AspspConsentData;
 import de.adorsys.psd2.xs2a.spi.domain.authorisation.SpiAuthenticationObject;
 import de.adorsys.psd2.xs2a.spi.domain.authorisation.SpiAuthorisationStatus;
 import de.adorsys.psd2.xs2a.spi.domain.authorisation.SpiAuthorizationCodeResult;
+import de.adorsys.psd2.xs2a.spi.domain.payment.SpiPeriodicPayment;
+import de.adorsys.psd2.xs2a.spi.domain.payment.SpiSinglePayment;
 import de.adorsys.psd2.xs2a.spi.domain.psu.SpiPsuData;
 import de.adorsys.psd2.xs2a.spi.domain.response.SpiResponse;
 import de.adorsys.psd2.xs2a.spi.service.PaymentAuthorisationSpi;
@@ -31,7 +33,16 @@ public class PaymentAuthorisationSpiImpl implements PaymentAuthorisationSpi {
       SpiPayment spiPayment,
       AspspConsentData aspspConsentData) {
 
-    return authorisationService.authorisePsu(spiPsuData, password, aspspConsentData);
+    String iban = null;
+
+    if (spiPayment instanceof SpiSinglePayment) {
+      iban = ((SpiSinglePayment) spiPayment).getDebtorAccount().getIban();
+    }
+    if (spiPayment instanceof SpiPeriodicPayment) {
+      iban = ((SpiPeriodicPayment) spiPayment).getDebtorAccount().getIban();
+    }
+
+    return authorisationService.authorisePsu(spiPsuData, password, iban, aspspConsentData);
   }
 
   @Override

--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/pis/PaymentCancellationSpiImpl.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/pis/PaymentCancellationSpiImpl.java
@@ -11,6 +11,8 @@ import de.adorsys.psd2.xs2a.spi.domain.authorisation.SpiAuthorisationStatus;
 import de.adorsys.psd2.xs2a.spi.domain.authorisation.SpiAuthorizationCodeResult;
 import de.adorsys.psd2.xs2a.spi.domain.authorisation.SpiScaConfirmation;
 import de.adorsys.psd2.xs2a.spi.domain.common.SpiTransactionStatus;
+import de.adorsys.psd2.xs2a.spi.domain.payment.SpiPeriodicPayment;
+import de.adorsys.psd2.xs2a.spi.domain.payment.SpiSinglePayment;
 import de.adorsys.psd2.xs2a.spi.domain.payment.response.SpiPaymentCancellationResponse;
 import de.adorsys.psd2.xs2a.spi.domain.psu.SpiPsuData;
 import de.adorsys.psd2.xs2a.spi.domain.response.SpiResponse;
@@ -89,7 +91,16 @@ public class PaymentCancellationSpiImpl implements PaymentCancellationSpi {
   @Override
   public SpiResponse<SpiAuthorisationStatus> authorisePsu(@NotNull SpiPsuData spiPsuData,
       String password, SpiPayment spiPayment, AspspConsentData aspspConsentData) {
-    return authorisationService.authorisePsu(spiPsuData, password, aspspConsentData);
+    String iban = null;
+
+    if (spiPayment instanceof SpiSinglePayment) {
+      iban = ((SpiSinglePayment) spiPayment).getDebtorAccount().getIban();
+    }
+    if (spiPayment instanceof SpiPeriodicPayment) {
+      iban = ((SpiPeriodicPayment) spiPayment).getDebtorAccount().getIban();
+    }
+
+    return authorisationService.authorisePsu(spiPsuData, password, iban, aspspConsentData);
   }
 
   @Override

--- a/service/src/test/java/de/adorsys/psd2/sandbox/xs2a/ais/AIS.feature
+++ b/service/src/test/java/de/adorsys/psd2/sandbox/xs2a/ais/AIS.feature
@@ -16,6 +16,14 @@ Feature: AIS
       | null                                          | DE94500105178833114935 | null                   | 200  |
       | DE94500105178833114935;DE96500105179669622432 | DE94500105178833114935 | null                   | 200  |
 
+  Scenario Outline: PSU Validation AIS
+    Given PSU created a consent on dedicated accounts for account information <accounts>, balances <balances> and transactions <transactions>
+    When Another PSU tries to authorise the consent with psu-id <psu-id>, password <password>
+    Then an appropriate error and response code <code> are received
+    Examples:
+      | accounts               | balances               | transactions | psu-id | password | code |
+      | DE94500105178833114935 | DE94500105178833114935 | null         | PSU-2  | 12345    | 401  |
+
     ################################################################################################
     #                                                                                              #
     # Consent Status                                                                               #

--- a/service/src/test/java/de/adorsys/psd2/sandbox/xs2a/pis/PIS.feature
+++ b/service/src/test/java/de/adorsys/psd2/sandbox/xs2a/pis/PIS.feature
@@ -32,6 +32,15 @@ Feature: Payment Initiation Service
       | payment-type | payment-product       | psu-id | password | sca-method | tan   | sca-status | code |
       | single       | sepa-credit-transfers | PSU-1  | 12345    | SMS_OTP    | 54321 | finalised  | 200  |
 
+  Scenario Outline: PSU Validation PIS
+    Given PSU initiated a single payment using the payment product <payment-product>
+    And PSU created an authorisation resource
+    When Another PSU tries to update the resource with his <psu-id> and <password>
+    Then an appropriate error and response code <code> are received
+    Examples:
+      | payment-product       | psu-id | password | code |
+      | sepa-credit-transfers | PSU-2  | 12345    | 401  |
+
     ################################################################################################
     #                                                                                              #
     # Payment Status                                                                               #


### PR DESCRIPTION
# Summary

* When creating a consent or initiating a payment, the PSU (provided at SCA) is getting checked to match the account referred to in the payment/consent

# Checklist for Definition of Done

* [x] Code is technically reviewed by myself
* [x] Code is manually tested
* [x] Pipeline is green
* [x] Automatic tests for new functionality are created
* [x] ~~Documentation is updated~~
* [x] Branch is rebased and therefore ready to merge
* [x] Git history is clean
