### PR TITLE
Fix order in which we save entities

### DIFF
--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/redirect/RedirectService.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/service/redirect/RedirectService.java
@@ -72,7 +72,7 @@ public class RedirectService {
     }
     AisConsentAuthorization aisConsentAuth = aisConsentAuthorization.get();
 
-    AisConsent consent = aisConsentRepository.findOne(aisConsentAuth.getId());
+    AisConsent consent = aisConsentAuth.getConsent();
 
     Optional<TestPsu> psu = testDataService.getPsu(psuId);
     if (psu.isPresent()) {
@@ -83,7 +83,6 @@ public class RedirectService {
       aisConsentAuth.setScaStatus(newScaStatus);
 
     }
-    aisConsentRepository.save(consent);
     aisConsentAuthorizationRepository.save(aisConsentAuth);
   }
 
@@ -106,14 +105,13 @@ public class RedirectService {
 
     PisAuthorization paymentAuth = pisAuthorization.get();
 
-    Optional<List<PisPaymentData>> pisPaymentDataList = pisPaymentDataRepository
-        .findByPaymentId(paymentAuth.getPaymentData().getPaymentId());
+    List<PisPaymentData> pisPaymentDataList = paymentAuth.getPaymentData().getPayments();
 
-    if (!pisPaymentDataList.isPresent() || pisPaymentDataList.get().isEmpty()) {
+    if (pisPaymentDataList.isEmpty()) {
       //TODO handle error case
       return;
     }
-    PisPaymentData pisPaymentData = pisPaymentDataList.get().get(0);
+    PisPaymentData pisPaymentData = pisPaymentDataList.get(0);
 
     Optional<TestPsu> psu = testDataService.getPsu(psuId);
 
@@ -151,8 +149,6 @@ public class RedirectService {
         paymentAuth.setScaStatus(newScaStatus);
       }
       pisAuthorizationRepository.save(paymentAuth);
-      pisPaymentDataRepository.save(pisPaymentData);
-      pisCommonPaymentDataRepository.save(pisPaymentData.getPaymentData());
     }
   }
 


### PR DESCRIPTION
# Summary

Looks like we have a problem in our dev stage. On localhost everything
behaves as expected and Hibernate returns proper wrappers for the same
entities. In dev somehow we get different object instances for the same
entity and update the consent status only in of of them. Depending on
the save order we lose updates. 

Now we fetch the root entity and get the childs directly from it instead of 
going through the repo. So same object instances are guaranteed. Also, 
because in XS2A everything seems to use CascadeType.ALL, it's enough 
to just save the root.

# Checklist for Definition of Done

Depending on the task some of the following jobs are not relevant. Please check the items or cross them out (`~~`text`~~`).

* [x] Code is technically reviewed by myself
* [x] Code is manually tested
* [x] Pipeline is green
* [x] Branch is rebased and therefore ready to merge
* [x] Git history is clean
