### PR TITLE
Fix a pretty unusual typo

### DIFF
--- a/arc42/src/07_deployment_view.adoc
+++ b/arc42/src/07_deployment_view.adoc
@@ -114,7 +114,7 @@ include::../../service/src/main/resources/testdata.yml[]
 
 Every PSU has one or more accounts. The account order _does_ matter (e.g. the first IBAN of _PSU-Successful_ is always picked for the giro account). You can override the configuration by placing an edited copy in `$CWD/config` next to the JAR.
 
-WARNING: Make sure that every IBAN you use is valid. We do not check externally set IBANs for correctness. If you use invalid IBANs, you might encounter problems when interacting with the XS2A API or with external systems. If a PSU has more than one IBAN, you need to supply all of them or the application won't start. To help with configuration and debugging, the effective `TestDataConfigura†ion` is logged (`INFO`) to the console at startup.
+WARNING: Make sure that every IBAN you use is valid. We do not check externally set IBANs for correctness. If you use invalid IBANs, you might encounter problems when interacting with the XS2A API or with external systems. If a PSU has more than one IBAN, you need to supply all of them or the application won't start. To help with configuration and debugging, the effective `TestDataConfiguration` is logged (`INFO`) to the console at startup.
 
 See <<Configuration>> for more information about the Spring Boot configuration mechanism.
 


### PR DESCRIPTION
Looks like I wrote `Configura†ion` instead of `Configuration` 🤷‍♂️ 