### PR TITLE
Fixes serializing LocalDate as [YYYY, MM, DD]

### DIFF
--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/Xs2aConfig.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/Xs2aConfig.java
@@ -128,12 +128,6 @@ public class Xs2aConfig {
   @Configuration
   static class SandboxObjectMapperConfig extends ObjectMapperConfig {
 
-    private ObjectMapperConfig original;
-
-    public SandboxObjectMapperConfig(ObjectMapperConfig original) {
-      this.original = original;
-    }
-
     @Bean
     @Primary
     ObjectMapper sandboxObjectMapper() {

--- a/service/src/main/resources/sandbox-application.properties
+++ b/service/src/main/resources/sandbox-application.properties
@@ -14,6 +14,9 @@ endpoints.info.enabled=true
 endpoints.metrics.enabled=true
 endpoints.xs2aSpecVersion.enabled=true
 
+# fixes writing dates as [2019, 10, 01]
+spring.jackson.serialization.write-dates-as-timestamps=false
+
 sandbox.feature.ui.enabled=true
 
 sandbox.xs2a.spec=psd2-api-1.3-20181220.yaml


### PR DESCRIPTION
# Summary

Everything looks good in our tests but in prod dates are written as
timestamps despite being disabled in our `@Primary ObjectMapper`.

# Checklist for Definition of Done

Depending on the task some of the following jobs are not relevant. Please check the items or cross them out (`~~`text`~~`).

* [x] Code is technically reviewed by myself
* [x] Code is manually tested
* [x] Pipeline is green
* [x] Automatic tests for new functionality are created
* [x] Documentation is updated
* [x] Branch is rebased and therefore ready to merge
* [x] Git history is clean
