### PR TITLE
Allow empty lines in transactions file upload

### DIFF
--- a/arc42/src/07_deployment_view.adoc
+++ b/arc42/src/07_deployment_view.adoc
@@ -134,6 +134,7 @@ The CSV must comply with the following restrictions:
 - A header line is mandatory and must match the example
 - Dates must be in the ISO format (YYYY-MM-DD)
 - Payment amounts must use `.` instead of `,` as floating point separator
+- Empty lines will be skipped
 
 
 See <<Configuration>> for more information about the Spring Boot configuration mechanism.

--- a/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/testdata/TestDataFileReader.java
+++ b/service/src/main/java/de/adorsys/psd2/sandbox/xs2a/testdata/TestDataFileReader.java
@@ -66,14 +66,20 @@ class TestDataFileReader {
       Transaction transaction;
 
       for (CSVRecord csvRecord : csvParser) {
-        transaction = mapTransactionFromFile(csvRecord);
-        transactionMap.put(transaction.getTransactionId(), transaction);
+        if (!isEmptyLine(csvRecord)) {
+          transaction = mapTransactionFromFile(csvRecord);
+          transactionMap.put(transaction.getTransactionId(), transaction);
+        }
       }
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
 
     return transactionMap;
+  }
+
+  private boolean isEmptyLine(CSVRecord csvRecord) {
+    return csvRecord.size() == 1;
   }
 
   private Transaction mapTransactionFromFile(CSVRecord csvRecord) throws ParseException {

--- a/service/src/test/java/de/adorsys/psd2/sandbox/xs2a/testdata/TestDataFileReaderTest.java
+++ b/service/src/test/java/de/adorsys/psd2/sandbox/xs2a/testdata/TestDataFileReaderTest.java
@@ -81,4 +81,18 @@ public class TestDataFileReaderTest {
           e.getMessage());
     }
   }
+
+  @Test
+  public void readFileWithWrongEmptyLine() {
+    when(resourceLoader.getResource(anyString()))
+        .thenReturn(new ClassPathResource("/testData/transactions_dump_empty_line.csv"));
+
+    HashMap<String, Transaction> transactions = testDataFileReader.readTransactionsFromFile();
+
+    transactions.forEach((key, value) -> {
+      assertThat(false, equalTo(value.getRemittanceInfo().isEmpty()));
+      assertThat(BigDecimal.class, equalTo(value.getAmount().getAmount().getClass()));
+    });
+    assertThat(transactions.size(), equalTo(5));
+  }
 }

--- a/service/src/test/resources/testData/transactions_dump_empty_line.csv
+++ b/service/src/test/resources/testData/transactions_dump_empty_line.csv
@@ -1,0 +1,9 @@
+bookingStatus|endToEndId|mandateId|creditorId|bookingDate|valueDate|currency|amount|creditorName|creditorIban|creditorAccountCurrency|ultimateCreditor|debtorName|debtorIban|debtorAccountCurrency|ultimateDebtor|remittanceInformationUnstructured|remittanceInformationStructured|purposeCode|bankTransactionCode|proprietaryBankTransactionCode
+
+booked||||2018-08-12|2018-08-12|EUR|-52.93|Tankstelle Weyarn Munchener Strase 32//Weyarn/DE|DE13760365681209386222|EUR||Isabella Ionescu|DE13760365689669622432|EUR||2018-07-20T15:08 Debitk.3 2019-03|2018-07-20T15:08 Debitk.3 2019-03|OTHR|5|5
+
+booked||||2018-08-01|2018-08-01|EUR|2500|Felix Borchert & Söhne GmbH|DE68760365687914626923|EUR||Isabella Ionescu|DE13760365689669622432|EUR||Gehalt August 2018|Gehalt August 2018|OTHR|5|5
+
+booked||||2018-02-01|2018-02-01|EUR|-17.50|CLIMBING-SOLUTIONS GMBH//Stuttgart/DE|DE68760365687914626923|EUR||Isabella Ionescu|DE13760365689669622432|EUR||2018-10-08T11:05 Debitk.3 2029-03|2018-10-08T11:05 Debitk.3 2029-03|OTHR|5|5
+booked||||2018-08-18|2018-08-18|EUR|-830|Hans Schlegl|DE68760365687914626923|EUR||Isabella Ionescu|DE13760365689669622432|EUR||Miete, Grünwälderstr. 49, 2.OG rechts|Miete, Grünwälderstr. 49, 2.OG rechts|OTHR|5|5
+booked||||2019-02-01|2019-02-01|EUR|-67.50|Strom-Gesellschaft Nürnberg|DE68760365687914626923|EUR||Isabella Ionescu|DE13760365689669622432|EUR||KTO 84633821 Abschlag 67,00 EUR faellig 01.08.18 Moritz-Str. 12|KTO 84633821 Abschlag 67,00 EUR faellig 01.08.18 Moritz-Str. 12|OTHR|5|5


### PR DESCRIPTION
# Summary

* Empty lines in the file `transactions.csv` do not trigger a parse error but will be ignored

# Checklist for Definition of Done

Depending on the task some of the following jobs are not relevant. Please check the items or cross them out (`~~`text`~~`).

* [x] Code is technically reviewed by myself
* [x] Code is manually tested
* [x] Pipeline is green
* [x] Automatic tests for new functionality are created
* [x] Documentation is updated
* [x] Branch is rebased and therefore ready to merge
* [x] Git history is clean
