### PR TITLE
fixed certificate format

### DIFF
--- a/service/certificate-generator/src/main/java/de/adorsys/psd2/sandbox/certificate/service/CertificateService.java
+++ b/service/certificate-generator/src/main/java/de/adorsys/psd2/sandbox/certificate/service/CertificateService.java
@@ -171,7 +171,7 @@ public class CertificateService {
         writer)) {
       pemWriter.writeObject(obj);
       pemWriter.flush();
-      return writer.toString().replaceAll("\n", "");
+      return writer.toString();
     } catch (IOException ex) {
       throw new CertificateException("Could not export certificate", ex);
     }


### PR DESCRIPTION
# Summary

_(What is this feature about)_
Fixed certificate formatting so it is accepted by x509 and other validators as is.